### PR TITLE
Fix for Unused local variable

### DIFF
--- a/pytest_html_plus/generate_html_report.py
+++ b/pytest_html_plus/generate_html_report.py
@@ -47,11 +47,6 @@ class JSONReporter:
         self.screenshots_dir = screenshots_dir
         self.output_dir = output_dir
         self.results = []
-        all_markers = set()
-        for test in self.results:
-            for marker in test.get("markers", []):
-                all_markers.add(marker)
-        all_markers = sorted(all_markers)
 
     def load_report(self):
         with open(self.report_path) as f:


### PR DESCRIPTION
To fix the issue, remove the unused local variable and its associated loop so that no unnecessary work is done and the linter/static analyzer is satisfied.

Concretely, in `pytest_html_plus/generate_html_report.py`, inside the `JSONReporter.__init__` method, delete the initialization of `all_markers`, the nested loops that add markers to it, and the final `all_markers = sorted(all_markers)` line. This does not change any externally visible behavior, because `self.results` is initialized to an empty list before the loop, so the loop has no effect, and `all_markers` is never used or stored on `self`.

No new imports, methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._