### PR TITLE
Fix for Unused import

### DIFF
--- a/pytest_html_plus/generate_html_report.py
+++ b/pytest_html_plus/generate_html_report.py
@@ -4,7 +4,6 @@ import json
 import os
 import shutil
 from datetime import datetime, timezone
-from sys import path
 
 from pytest_html_plus.compute_filter_counts import compute_filter_count
 from pytest_html_plus.utils import extract_error_block, extract_trace_block


### PR DESCRIPTION
The best fix is to remove the unused import `from sys import path` from `pytest_html_plus/generate_html_report.py`.

- **General approach:** delete imports that are not referenced anywhere in the file.
- **Specific change:** in the import section at the top of `pytest_html_plus/generate_html_report.py`, remove line 7 (`from sys import path`) and leave all other imports unchanged.
- **Why this is best:** it resolves the warning cleanly without changing runtime functionality, logic, or APIs.
- **No additional methods/definitions/imports** are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._