### PR TITLE
Implemented configuration for stdout and stderr capture

### DIFF
--- a/.github/workflows/unit-test-windows.yml
+++ b/.github/workflows/unit-test-windows.yml
@@ -60,6 +60,7 @@ jobs:
             --reruns 1 `
             --ignore=tests/browser `
             --plus-profile=ci `
+            --plus-output=failed-only `
             --git-branch "$BRANCH" `
             --git-commit "$COMMIT" `
             tests/
@@ -76,6 +77,7 @@ jobs:
             --reruns 1 `
             --ignore=tests/browser `
             --plus-profile=ci-warnings `
+            --plus-output=failed-only `
             --git-branch "$BRANCH" `
             --git-commit "$COMMIT" `
             tests/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,10 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
-_Changes merged to `main` but not yet released._
+### Added
+
+* Added `--plus-output` with `all`, `failed-only`, and `none` modes to control whether captured stdout/stderr are included in JSON, HTML, and generated XML reports.
+* Added `[tool.pytest-html-plus].output` and profile-level `output` configuration. Explicit CLI values override profiles, and profiles override the top-level setting.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ### Added
 
-* Added `--plus-output` with `all`, `failed-only`, and `none` modes to control whether captured stdout/stderr are included in JSON, HTML, and generated XML reports.
+* Added `--plus-output` with `all`, `failed-only`, and `none` modes to control whether captured stdout/stderr are included in JSON, HTML, and generated XML reports. The `failed-only` mode retains output for failures, setup/teardown errors, and XFAIL results.
 * Added profile-level `output` configuration. Explicit CLI values override profiles.
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+_Changes merged to `main` but not yet released._
+
+---
+
+## [1.2.0] — 2026-08-11
+
 ### Added
 
 * Added `--plus-output` with `all`, `failed-only`, and `none` modes to control whether captured stdout/stderr are included in JSON, HTML, and generated XML reports. The `failed-only` mode retains output for failures, setup/teardown errors, and XFAIL results.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Versions follow [Semantic Versioning](https://semver.org/).
 ### Added
 
 * Added `--plus-output` with `all`, `failed-only`, and `none` modes to control whether captured stdout/stderr are included in JSON, HTML, and generated XML reports.
-* Added `[tool.pytest-html-plus].output` and profile-level `output` configuration. Explicit CLI values override profiles, and profiles override the top-level setting.
+* Added profile-level `output` configuration. Explicit CLI values override profiles.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Just start typing, and the dashboard will instantly filter tests by:
 
 ![ScreenRecording2025-06-21at2 52 49PM-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/b9760927-7c67-4bbf-b03d-e13964c727ee)
 
-#### 📝 Comprehensive output capture: All your test logs with loggers, print() statements, and screenshots are automatically captured and embedded in the report...
+#### 📝 Configurable output capture: Test logs, print() statements, stdout/stderr, and screenshots are automatically captured and embedded in the report. Use `--plus-output=failed-only` to omit captured stdout/stderr from passing tests and reduce report size; logger and screenshot behavior is unchanged.
 
 ![ezgif-744a5d34a4c46d](https://github.com/user-attachments/assets/209cd2c0-d33b-48ec-b58b-8c8991ce35be)
 
@@ -141,7 +141,7 @@ Just start typing, and the dashboard will instantly filter tests by:
 | 🐢 **Slow test highlighting** | Slowest tests in the run automatically flagged |
 | 📋 **Copy-to-clipboard** | Copy test path, logs, trace, and errors in one click |
 | 📦 **Run metadata** | Branch, commit SHA, environment, and custom metadata embedded in the report header |
-| 📝 **Comprehensive log capture** | `print()`, logger output, and stdout/stderr automatically captured per test |
+| 📝 **Configurable stream capture** | Control captured stdout/stderr with `--plus-output`; logger and screenshot behavior remains unchanged |
 | ⚡ **xdist support** | Parallel runs with `pytest-xdist` produce a single merged report, no extra steps |
 | 🌐 **Auto-open report** | `--should-open-report` opens the report in your browser after a run (always / failed / never) |
 | 📄 **JSON report** | Raw JSON output (`--json-report`) for custom dashboards or post-processing |

--- a/docs/cli/cli.rst
+++ b/docs/cli/cli.rst
@@ -21,6 +21,10 @@ Overview
      - When to capture screenshots
      - ``failed``
      - Useful in flaky UI tests to get screenshots on failure
+   * - ``--plus-output``
+     - Control which captured stdout/stderr streams are included in reports
+     - ``all``
+     - Reduce report size by omitting output from passing tests or all tests
    * - ``--html-output``
      - Directory for HTML output
      - ``report_output``
@@ -72,6 +76,7 @@ For detailed information, examples, and best practices for each parameter, see:
 
    cli/json-report
    cli/capture-screenshots
+   cli/plus-output
    cli/html-output
    cli/send-email
    cli/should-open-report

--- a/docs/cli/plus-output.rst
+++ b/docs/cli/plus-output.rst
@@ -28,16 +28,6 @@ Command-line usage
 
    pytest --plus-output=failed-only
 
-Top-level configuration
------------------------
-
-Configure the default policy for the project in ``pyproject.toml``:
-
-.. code-block:: toml
-
-   [tool.pytest-html-plus]
-   output = "failed-only"
-
 Profile configuration
 ---------------------
 
@@ -54,9 +44,8 @@ Then activate it with:
 
    pytest --plus-profile=ci
 
-An explicit ``--plus-output`` value overrides the selected profile. A profile
-overrides the top-level project setting, and ``all`` is used when no value is
-configured.
+An explicit ``--plus-output`` value overrides the selected profile. The
+default value is ``all`` when neither a CLI option nor a profile is supplied.
 
 Retry information
 -----------------

--- a/docs/cli/plus-output.rst
+++ b/docs/cli/plus-output.rst
@@ -1,0 +1,66 @@
+Captured Output (``--plus-output``)
+===================================
+
+The ``--plus-output`` option controls whether captured stdout and stderr are
+included in generated JSON, HTML, and XML reports. It can reduce artifact size
+for suites where passing tests produce large amounts of output.
+
+Modes
+-----
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 80
+
+   * - Value
+     - Behavior
+   * - ``all``
+     - Include stdout and stderr for every reported test. This is the default.
+   * - ``failed-only``
+     - Include stdout and stderr only for failed tests and setup/teardown errors.
+   * - ``none``
+     - Do not include captured stdout or stderr in generated reports.
+
+Command-line usage
+------------------
+
+.. code-block:: bash
+
+   pytest --plus-output=failed-only
+
+Top-level configuration
+-----------------------
+
+Configure the default policy for the project in ``pyproject.toml``:
+
+.. code-block:: toml
+
+   [tool.pytest-html-plus]
+   output = "failed-only"
+
+Profile configuration
+---------------------
+
+The policy can also be included in a reusable profile:
+
+.. code-block:: toml
+
+   [tool.pytest-html-plus.profiles.ci]
+   output = "failed-only"
+
+Then activate it with:
+
+.. code-block:: bash
+
+   pytest --plus-profile=ci
+
+An explicit ``--plus-output`` value overrides the selected profile. A profile
+overrides the top-level project setting, and ``all`` is used when no value is
+configured.
+
+Retry information
+-----------------
+
+This option controls only the top-level ``stdout`` and ``stderr`` fields. Retry
+attempt status, error, and trace information remains unchanged. Individual
+attempts do not store stdout or stderr.

--- a/docs/cli/plus-output.rst
+++ b/docs/cli/plus-output.rst
@@ -17,7 +17,8 @@ Modes
    * - ``all``
      - Include stdout and stderr for every reported test. This is the default.
    * - ``failed-only``
-     - Include stdout and stderr only for failed tests and setup/teardown errors.
+     - Include stdout and stderr only for failed tests, setup/teardown errors,
+       and expected failures (XFAIL). Ordinary skips and passing tests are omitted.
    * - ``none``
      - Do not include captured stdout or stderr in generated reports.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -8,7 +8,7 @@ sys.path.insert(0, os.path.abspath(".."))
 project = "pytest-html-plus"
 copyright = "2026, ReporterPlus"
 author = "ReporterPlus"
-release = "1.1.0"
+release = "1.2.0"
 
 extensions = [
     "sphinx.ext.autodoc",

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,6 +17,7 @@ Welcome to pytest-html-plus
    cli/cli
    cli/html-output
    cli/json-report
+   cli/plus-output
    cli/generate-xml
    cli/screenshots
    cli/send-email

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -28,13 +28,8 @@ Output Capture Policy
 ---------------------
 
 By default, captured stdout and stderr are included for every reported test.
-To reduce JSON and HTML report size for verbose suites, configure an output
-policy in ``pyproject.toml``:
-
-.. code-block:: toml
-
-   [tool.pytest-html-plus]
-   output = "failed-only"
+To reduce JSON and HTML report size for verbose suites, select an output policy
+with ``--plus-output``.
 
 The supported values are:
 
@@ -47,7 +42,7 @@ The supported values are:
 The policy controls the top-level ``stdout`` and ``stderr`` report fields. It
 does not change retry attempt errors or traces.
 
-You can override the configured value for a particular run:
+For example:
 
 .. code-block:: bash
 
@@ -82,9 +77,8 @@ for a specific run:
 
    pytest --plus-profile=ci --json-report=override.json
 
-Configuration precedence, from highest to lowest, is an explicit CLI option,
-the selected profile, the top-level ``[tool.pytest-html-plus]`` configuration,
-and finally the default value.
+An explicit CLI option overrides the selected profile. If neither is supplied,
+the default value is ``all``.
 
 The JSON report (`final_report.json`)
 --------------------------------------

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -35,8 +35,9 @@ The supported values are:
 
 * ``all``: Include stdout and stderr for every test. This is the default and
   preserves the existing behavior.
-* ``failed-only``: Include stdout and stderr only for failed tests and
-  setup/teardown errors.
+* ``failed-only``: Include stdout and stderr only for failed tests,
+  setup/teardown errors, and expected failures (XFAIL). Ordinary skips and
+  passing tests do not include captured output.
 * ``none``: Do not include captured stdout or stderr in the generated reports.
 
 The policy controls the top-level ``stdout`` and ``stderr`` report fields. It

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -24,6 +24,35 @@ This will:
 - Generate a combined JSON test report called final_report.json
 - Create a visual HTML report inside the `report_output/` folder
 
+Output Capture Policy
+---------------------
+
+By default, captured stdout and stderr are included for every reported test.
+To reduce JSON and HTML report size for verbose suites, configure an output
+policy in ``pyproject.toml``:
+
+.. code-block:: toml
+
+   [tool.pytest-html-plus]
+   output = "failed-only"
+
+The supported values are:
+
+* ``all``: Include stdout and stderr for every test. This is the default and
+  preserves the existing behavior.
+* ``failed-only``: Include stdout and stderr only for failed tests and
+  setup/teardown errors.
+* ``none``: Do not include captured stdout or stderr in the generated reports.
+
+The policy controls the top-level ``stdout`` and ``stderr`` report fields. It
+does not change retry attempt errors or traces.
+
+You can override the configured value for a particular run:
+
+.. code-block:: bash
+
+   pytest --plus-output=failed-only
+
 Reusable Profiles
 -----------------
 
@@ -37,6 +66,7 @@ define a named profile in ``pyproject.toml`` and activate it with
    html-output = "ci-report"
    json-report = "ci.json"
    capture-screenshots = "failed"
+   output = "failed-only"
    generate-xml = true
    xml-report = "ci.xml"
 
@@ -51,6 +81,10 @@ for a specific run:
 .. code-block:: bash
 
    pytest --plus-profile=ci --json-report=override.json
+
+Configuration precedence, from highest to lowest, is an explicit CLI option,
+the selected profile, the top-level ``[tool.pytest-html-plus]`` configuration,
+and finally the default value.
 
 The JSON report (`final_report.json`)
 --------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pytest-html-plus"
-version = "1.1.1"
+version = "1.2.0"
 description = "Generate Actionable, automatic screenshots, unified Mobile friendly Pytest HTML report in less than 3 seconds — no hooks, merge plugins, no config, xdist-ready."
 readme = "README.md"
 authors = ["reporterplus"]

--- a/pytest_html_plus/plugin.py
+++ b/pytest_html_plus/plugin.py
@@ -31,6 +31,8 @@ python_executable = shutil.which("python3") or shutil.which("python")
 test_screenshot_paths = {}
 PROFILE_OPTION = "--plus-profile"
 PROFILE_SECTION = ("tool", "pytest-html-plus", "profiles")
+OUTPUT_OPTION = "--plus-output"
+OUTPUT_CHOICES = ("all", "failed-only", "none")
 PROFILE_OPTION_MAP = {
     "json-report": {"flag": "--json-report", "kind": "value"},
     "capture-screenshots": {"flag": "--capture-screenshots", "kind": "value"},
@@ -43,6 +45,7 @@ PROFILE_OPTION_MAP = {
     "git-branch": {"flag": "--git-branch", "kind": "value"},
     "git-commit": {"flag": "--git-commit", "kind": "value"},
     "rp-env": {"flag": "--rp-env", "kind": "value"},
+    "output": {"flag": OUTPUT_OPTION, "kind": "value"},
 }
 
 
@@ -93,6 +96,42 @@ def _read_profiles_from_pyproject(start_path=None):
         )
 
     return profiles
+
+
+def _read_output_from_pyproject(start_path=None):
+    pyproject_file = _find_pyproject_toml(start_path=start_path)
+    if pyproject_file is None:
+        return None
+
+    try:
+        with pyproject_file.open("rb") as fh:
+            pyproject_data = tomllib.load(fh)
+    except tomllib.TOMLDecodeError as exc:
+        raise pytest.UsageError(f"Invalid TOML in {pyproject_file}: {exc}") from exc
+
+    plus_config = pyproject_data.get("tool", {}).get("pytest-html-plus", {})
+    if not isinstance(plus_config, dict):
+        raise pytest.UsageError(
+            "Expected [tool.pytest-html-plus] to be a TOML table"
+        )
+
+    output = plus_config.get("output")
+    if output is None:
+        return None
+    if not isinstance(output, str) or output not in OUTPUT_CHOICES:
+        choices = ", ".join(OUTPUT_CHOICES)
+        raise pytest.UsageError(
+            f"[tool.pytest-html-plus] output must be one of: {choices}"
+        )
+
+    return output
+
+
+def apply_plus_output_arg(args, start_path=None):
+    output = _read_output_from_pyproject(start_path=start_path)
+    if output is None:
+        return list(args)
+    return [f"{OUTPUT_OPTION}={output}", *args]
 
 
 def _build_profile_args(profile_name, start_path=None):
@@ -250,6 +289,13 @@ def pytest_runtest_makereport(item, call):
         if report.when in ("setup", "teardown") and report.failed:
             status = "error"
 
+        output_policy = config.getoption(OUTPUT_OPTION)
+        include_output = output_policy == "all" or (
+            output_policy == "failed-only" and report.failed
+        )
+        stdout = getattr(report, "capstdout", "") if include_output else ""
+        stderr = getattr(report, "capstderr", "") if include_output else ""
+
         reporter.log_result(
             test_name=test_name,
             nodeid=item.nodeid,
@@ -261,8 +307,8 @@ def pytest_runtest_makereport(item, call):
             markers=[m.name for m in item.iter_markers()],
             filepath=item.location[0],
             lineno=item.location[1],
-            stdout=getattr(report, "capstdout", ""),
-            stderr=getattr(report, "capstderr", ""),
+            stdout=stdout,
+            stderr=stderr,
             screenshot=screenshot_path,
             logs=caplog_text,
             worker=worker_id,
@@ -414,6 +460,7 @@ def pytest_sessionstart(session):
 
 def pytest_load_initial_conftests(args):
     args[:] = apply_plus_profile_args(args, start_path=Path.cwd())
+    args[:] = apply_plus_output_arg(args, start_path=Path.cwd())
     if not any(arg.startswith("--capture") for arg in args):
         args.append("--capture=tee-sys")
 
@@ -439,6 +486,16 @@ def pytest_addoption(parser):
         default="failed",
         choices=["failed", "all", "none"],
         help="Capture screenshots: failed (default), all, or none",
+    )
+    group.addoption(
+        OUTPUT_OPTION,
+        action="store",
+        default="all",
+        choices=OUTPUT_CHOICES,
+        help=(
+            "Include captured stdout/stderr in reports: all (default), "
+            "failed-only, or none"
+        ),
     )
     group.addoption("--html-output", default="report_output")
     group.addoption("--screenshots", default="screenshots")

--- a/pytest_html_plus/plugin.py
+++ b/pytest_html_plus/plugin.py
@@ -254,8 +254,10 @@ def pytest_runtest_makereport(item, call):
             status = "error"
 
         output_policy = config.getoption(OUTPUT_OPTION)
+        is_expected_failure = report.skipped and hasattr(report, "wasxfail")
         include_output = output_policy == "all" or (
-            output_policy == "failed-only" and report.failed
+            output_policy == "failed-only"
+            and (report.failed or is_expected_failure)
         )
         stdout = getattr(report, "capstdout", "") if include_output else ""
         stderr = getattr(report, "capstderr", "") if include_output else ""

--- a/pytest_html_plus/plugin.py
+++ b/pytest_html_plus/plugin.py
@@ -98,42 +98,6 @@ def _read_profiles_from_pyproject(start_path=None):
     return profiles
 
 
-def _read_output_from_pyproject(start_path=None):
-    pyproject_file = _find_pyproject_toml(start_path=start_path)
-    if pyproject_file is None:
-        return None
-
-    try:
-        with pyproject_file.open("rb") as fh:
-            pyproject_data = tomllib.load(fh)
-    except tomllib.TOMLDecodeError as exc:
-        raise pytest.UsageError(f"Invalid TOML in {pyproject_file}: {exc}") from exc
-
-    plus_config = pyproject_data.get("tool", {}).get("pytest-html-plus", {})
-    if not isinstance(plus_config, dict):
-        raise pytest.UsageError(
-            "Expected [tool.pytest-html-plus] to be a TOML table"
-        )
-
-    output = plus_config.get("output")
-    if output is None:
-        return None
-    if not isinstance(output, str) or output not in OUTPUT_CHOICES:
-        choices = ", ".join(OUTPUT_CHOICES)
-        raise pytest.UsageError(
-            f"[tool.pytest-html-plus] output must be one of: {choices}"
-        )
-
-    return output
-
-
-def apply_plus_output_arg(args, start_path=None):
-    output = _read_output_from_pyproject(start_path=start_path)
-    if output is None:
-        return list(args)
-    return [f"{OUTPUT_OPTION}={output}", *args]
-
-
 def _build_profile_args(profile_name, start_path=None):
     profiles = _read_profiles_from_pyproject(start_path=start_path)
     profile = profiles.get(profile_name)
@@ -460,7 +424,6 @@ def pytest_sessionstart(session):
 
 def pytest_load_initial_conftests(args):
     args[:] = apply_plus_profile_args(args, start_path=Path.cwd())
-    args[:] = apply_plus_output_arg(args, start_path=Path.cwd())
     if not any(arg.startswith("--capture") for arg in args):
         args.append("--capture=tee-sys")
 

--- a/tests/unit/test_json_merger.py
+++ b/tests/unit/test_json_merger.py
@@ -45,7 +45,7 @@ def test_merge_json_reports_creates_merged_file(mock_json_files):
     with open(output_file) as f:
         data = json.load(f)
 
-    assert "results" in data
+    assert "resultss" in data
     assert "filters" in data
 
     results = data["results"]

--- a/tests/unit/test_json_merger.py
+++ b/tests/unit/test_json_merger.py
@@ -1,4 +1,4 @@
-import json
+Jimport json
 
 import pytest
 
@@ -45,7 +45,7 @@ def test_merge_json_reports_creates_merged_file(mock_json_files):
     with open(output_file) as f:
         data = json.load(f)
 
-    assert "resultss" in data
+    assert "results" in data
     assert "filters" in data
 
     results = data["results"]

--- a/tests/unit/test_json_merger.py
+++ b/tests/unit/test_json_merger.py
@@ -1,4 +1,4 @@
-Jimport json
+import json
 
 import pytest
 

--- a/tests/unit/test_plugin_logging.py
+++ b/tests/unit/test_plugin_logging.py
@@ -3,6 +3,8 @@ import subprocess
 import sys
 import textwrap
 
+import pytest
+
 # The plugin saves the JSON report inside the html-output folder
 # (default: "report_output"), not at the cwd root.
 REPORT_FILENAME = "report.json"
@@ -169,3 +171,116 @@ def test_report_file_contains_filters(tmp_path):
     assert "filters" in data
     assert "total" in data["filters"]
     assert data["filters"]["total"] == 2
+
+
+@pytest.mark.parametrize(
+    ("policy", "should_include"),
+    [
+        (None, True),
+        ("all", True),
+        ("failed-only", False),
+        ("none", False),
+    ],
+)
+def test_plus_output_policy_for_passing_test(tmp_path, policy, should_include):
+    extra_args = [f"--plus-output={policy}"] if policy else []
+    result, report_file = run_pytest(
+        tmp_path,
+        """
+        import sys
+
+        def test_passes():
+            print("stdout from pass")
+            print("stderr from pass", file=sys.stderr)
+            assert True
+        """,
+        extra_args=extra_args,
+    )
+
+    assert result.returncode == 0, f"Pytest failed:\n{result.stderr}\n{result.stdout}"
+    test = next(
+        test
+        for test in load_results(report_file)
+        if test["nodeid"].endswith("test_passes")
+    )
+
+    if should_include:
+        assert "stdout from pass" in test["stdout"]
+        assert "stderr from pass" in test["stderr"]
+    else:
+        assert test["stdout"] == ""
+        assert test["stderr"] == ""
+
+
+@pytest.mark.parametrize(
+    ("policy", "should_include"),
+    [
+        ("all", True),
+        ("failed-only", True),
+        ("none", False),
+    ],
+)
+def test_plus_output_policy_for_failing_test(tmp_path, policy, should_include):
+    result, report_file = run_pytest(
+        tmp_path,
+        """
+        import sys
+
+        def test_fails():
+            print("stdout from failure")
+            print("stderr from failure", file=sys.stderr)
+            assert False, "intentional failure"
+        """,
+        extra_args=[f"--plus-output={policy}"],
+    )
+
+    assert result.returncode != 0
+    test = next(
+        test
+        for test in load_results(report_file)
+        if test["nodeid"].endswith("test_fails")
+    )
+
+    if should_include:
+        assert "stdout from failure" in test["stdout"]
+        assert "stderr from failure" in test["stderr"]
+    else:
+        assert test["stdout"] == ""
+        assert test["stderr"] == ""
+
+    assert test["error"]
+    assert test["trace"]
+    assert test["attempts"][0]["error"]
+    assert test["attempts"][0]["trace"]
+
+
+def test_failed_only_keeps_setup_failure_output(tmp_path):
+    result, report_file = run_pytest(
+        tmp_path,
+        """
+        import sys
+
+        import pytest
+
+        @pytest.fixture
+        def broken_fixture():
+            print("setup stdout")
+            print("setup stderr", file=sys.stderr)
+            raise RuntimeError("setup failed")
+
+        def test_setup_failure(broken_fixture):
+            pass
+        """,
+        extra_args=["--plus-output=failed-only"],
+    )
+
+    assert result.returncode != 0
+    test = next(
+        test
+        for test in load_results(report_file)
+        if test["nodeid"].endswith("test_setup_failure")
+    )
+
+    assert test["status"] == "error"
+    assert "setup stdout" in test["stdout"]
+    assert "setup stderr" in test["stderr"]

--- a/tests/unit/test_plugin_logging.py
+++ b/tests/unit/test_plugin_logging.py
@@ -284,3 +284,32 @@ def test_failed_only_keeps_setup_failure_output(tmp_path):
     assert test["status"] == "error"
     assert "setup stdout" in test["stdout"]
     assert "setup stderr" in test["stderr"]
+
+
+def test_failed_only_keeps_xfail_output(tmp_path):
+    result, report_file = run_pytest(
+        tmp_path,
+        """
+        import sys
+
+        import pytest
+
+        @pytest.mark.xfail(reason="known issue")
+        def test_expected_failure():
+            print("xfail stdout")
+            print("xfail stderr", file=sys.stderr)
+            assert False
+        """,
+        extra_args=["--plus-output=failed-only"],
+    )
+
+    assert result.returncode == 0
+    test = next(
+        test
+        for test in load_results(report_file)
+        if test["nodeid"].endswith("test_expected_failure")
+    )
+
+    assert test["status"] == "skipped"
+    assert "xfail stdout" in test["stdout"]
+    assert "xfail stderr" in test["stderr"]

--- a/tests/unit/test_profile_loading.py
+++ b/tests/unit/test_profile_loading.py
@@ -54,6 +54,23 @@ screenshots = "artifacts"
     assert args == ["--screenshots=artifacts", "-q"]
 
 
+def test_profile_supports_output_policy(tmp_path):
+    write_pyproject(
+        tmp_path,
+        """
+[tool.pytest-html-plus.profiles.ci]
+output = "failed-only"
+""".strip(),
+    )
+
+    args = apply_plus_profile_args(
+        ["--plus-profile=ci"],
+        start_path=tmp_path,
+    )
+
+    assert args == ["--plus-output=failed-only"]
+
+
 def test_invalid_profile_key_raises_usage_error(tmp_path):
     write_pyproject(
         tmp_path,


### PR DESCRIPTION
Closes #273 

## Summary

Closes #273.

Adds `--plus-output` to control whether captured stdout and stderr are included in generated reports.

Supported modes:

- `all` — include stdout/stderr for every test. This is the default and preserves existing behavior.
- `failed-only` — include stdout/stderr only for failed tests and setup/teardown errors.
- `none` — omit stdout/stderr for all tests.

## Usage

```bash
pytest --plus-output=failed-only

```

- [x] `make test` passes
- [x] `make lint` passes
- [x] Tests added or updated for changed behaviour
- [x] README / docs updated if user-facing behaviour changed
- [x] Changelog entry added under `[Unreleased]` in `CHANGELOG.md`
- [x] PR description explains what changed and why
- [x] Issue linked with `Closes #123` (if applicable)